### PR TITLE
Change asyncio.async to asyncio.ensure_future

### DIFF
--- a/aiosmtplib/__init__.py
+++ b/aiosmtplib/__init__.py
@@ -43,7 +43,7 @@ def main():
 
     loop = asyncio.get_event_loop()
     smtp = SMTP(hostname='localhost', port=25, loop=loop)
-    send_message = asyncio.async(smtp.sendmail(sender, recipients, message))
+    send_message = asyncio.ensure_future(smtp.sendmail(sender, recipients, message))
     loop.run_until_complete(send_message)
 
 


### PR DESCRIPTION
`asyncio.async` is a deprecated alias of `asyncio.ensure_future`, and `async` becomes a keyword in Python 3.7.